### PR TITLE
fix not class not found exception

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -16,7 +16,7 @@ class AppKernel extends Kernel
             new Symfony\Bundle\AsseticBundle\AsseticBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
-            new RedKiteCms\InstallerBundle\RedKiteCmsInstallerBundle(),
+            new RedKiteLabs\RedKiteCms\InstallerBundle\RedKiteCmsInstallerBundle(),
             new Acme\WebSiteBundle\AcmeWebSiteBundle(),
         );
 


### PR DESCRIPTION
PHP Fatal error:  Class 'RedKiteCms\InstallerBundle\RedKiteCmsInstallerBundle' not found in .../RedKiteCmsSandbox/app/AppKernel.php on line 19
